### PR TITLE
How to publish Github Pages from a private repo.

### DIFF
--- a/_lab/lab01.md
+++ b/_lab/lab01.md
@@ -148,41 +148,27 @@ So, don't repeat yourself:
 Signify that you are finished by committing code to a github repo that contains a modified version of ex08, with all of the
 following:
 
-* a `build.xml` file. You'll be making a few modifications to the `build.xml` to update the javadoc.
+* a `build.xml` file containing the ant tasks used to build the project.
 * a `src` subdirectory containing `Main.java`, `Rational.java`, and `RationalTest.java`
 * a `lib` subdirectory contining the jar file for JUnit
-* a `javadoc` subdirectory in which you have produced the javadoc by running `ant javadoc`
-
-Note that you will not be able to publish your javadoc online with the github pages technique (i.e. pushing to a gh-pages branch), because this only works with public repos, not with private ones.   So, we've added some instructions below for publishing the javadoc to a separate public repo with the name `{{page.num}}-javadoc-yourgithubid`.
+* a `docs` subdirectory in which you have produced javadoc by running `ant javadoc`
 
 Publishing your javadoc online
 ==============================
 
-1. Create a *public*_repo with the name `{{page.num}}-javadoc-yourgithubid` under the <https://github.com/{{page.org}}> organization with a `README.md` (it is not necessary to include a .gitignore).
-2. cd into your ~/cs56 directory (or into whatever directory you cloned your `{{page.num}}-yourgithubid` repo).  You want to clone your `{{page.num}}-javadoc-yourgithubid` repo into the same directory so that they are siblings, side-by-side in the same directory.
-3. We will now add some lines into your build.xml that copy the generated javadoc from your private repo to the public repo, 
-   and we'll set the default branch of the public repo to be gh-pages.
-   That process is explained in detail here: [Javadoc: publishing to github pages from private repo](https://ucsb-cs56-pconrad.github.io/topics/javadoc_publishing_to_github_pages_from_private_repo)
-4. Once you've followed the instructions in the link at step 3, your javadoc should be available online at a URL similar to
-   the following one (but with your githubid instead of `yourgithubid`).
-
-```
-    https://UCSB-CS56-F17.github.io/{{page.num}}-javadoc-yourgithubid/javadoc/index.html
-```
-
-If you run into difficulties, ask your mentor/TA/instructor if in class, or ask on Piazza if outside of class.
+1. Run `ant javadoc` to build your docs.
+2. You should now have a `docs` folder, and some files inside it. Push all of these to Github.
+3. In the Github UI, go to the Settings tab for your repo. Set your Github Pages source to "master branch /docs folder."
+4. Click the link that shows up once you change the source. You should see your javadoc.
 
 When you are finished
 =====================
 
 When you are finished, you'll have:
 
-* the url of your completed repo (e.g. <https://github.com/{{page.org}}/{{page.num}}-yourgithubid> )
-* the url of your javadoc (which will be in a separate public repo)
-  * URL of that repo will be: <https://github.com/{{page.org}}/{{page.num}}-javadoc-yourgithubid>
-  * When you push to your GitHub pages source branch, which should be `master` if you followed the [directions](https://ucsb-cs56-pconrad.github.io/topics/javadoc_publishing_to_github_pages_from_private_repo), that repo's content will be published at
-    <https://{{page.org}}.github.io/{{page.num}}-javadoc-yourgithubid/javadoc/index.html>
+* the url of your completed repo (e.g. <https://github.com/{{page.org}}/{{page.num}}-yourgithubid>)
+* the url of your javadoc (e.g. <https://{{page.org}}.github.io/{{page.num}}-yourgithubid/index.html>)
 
 Visit the [lab01 assignment on Gauchospace]({{page.gauchospace_link}}) to paste these URLs into the "online text" submission area for {{page.num}}.   Please make that your links are clickable&mdash;there are [instructions here on how to make links on Gauchospace clickable](https://ucsb-cs56-pconrad.github.io/topics/gauchospace_clickable_urls)
 
-f you worked in a pair, please register your pair as a group in submit.cs for {{page.num}} before submitting. One partner’s submission on submit.cs counts for both of you.
+If you worked in a pair, please register your pair as a group in submit.cs for {{page.num}} before submitting. One partner’s submission on submit.cs counts for both of you.

--- a/_lab/lab02.md
+++ b/_lab/lab02.md
@@ -269,33 +269,7 @@ In short:
 -   Modify the `.gitignore` anytime there is some other kind of file that you also want git to ignore
 
 
-Step 2: Making a parallel public javadoc repo
----------------------------------------------
-
-In lab01, we set up a public repo, `lab01-javadoc-githubid`, as a sibling of our private repo, `lab01-githubid`, so that
-we could publish our javadoc.
-
-In this step, please do the SAME thing for your {{page.num}} repo.
-
-Your public repo will have the same name as your private repo, except
-that it will start with `{{page.num}}-javadoc-` instead of `{{page.num}}-`.  The
-rest of the name is either a single github id, or a pair of githubids
-separated by an underscore.
-
-The instructions for setting this up are here:
-
-* [Javadoc: publishing to github pages for a private repo](https://ucsb-cs56-pconrad.github.io/topics/javadoc_publishing_to_github_pages_from_private_repo/)
-
-Once you've done these things, you are ready to move on to the Java programming part of this lab:
-* Set up this additional `{{page.num}}-javadoc_...` repo
-* Change the settings as needed to publish the content to github pages
-* Clone it as a sibling of your `{{page.num}}_...` repo
-* Make the necessary adjustments to the `build.xml` of your private repo
-* Generate the javadoc
-* Publish it in the public repo as a webpage
-
-
-Step 3: Java Programming
+Step 2: Java Programming
 ------------------------
 
 Your programming task in this lab can be described very simply:
@@ -425,11 +399,12 @@ First, check your code Check it against two things:
 
 Even if you "solo programmed" this lab, you may want to see if you can find someone in the lab that also solo programmed, and ask him/her to be a "rubric buddy" with whom you can take turns doing this checklist step.
 
+
 ### Updating javadoc
 
-If you are working along, right before you do the final submission, do a "git commit", "git push" and then run "ant javadoc".
-
-Then do the steps to publish the updated javadoc to your public repo.
+Make sure you have generated javadoc with `ant javadoc` and that those files are
+pushed to Github.  Make sure that you are publishing the `docs` folder from your
+master branch on Github Pages (see lab01 if you don't remember how to do this).
 
 
 ### Final git pull, git status, git add, git commit, git push origin master
@@ -439,12 +414,12 @@ Go through the git steps one last time in case you made any last minute changes.
 Step 4: Submitting on Gauchospace
 ---------------------------------
 
-Once you've done your final lookover and updated your javadoc, to let us know that you are finished with your lab, and that it is ready for grading, you should visit the {{page.num}} link on Gauchospace.com and follow the instructions
-there to link to both your {{page.num}} private repo, and the public repo for your javadoc.
+Once you've done your final lookover  and updated your javadoc  you should visit
+the ({{page.num}} link on Gauchospace)[{{page.gauchospace_url}}]  and follow the
+instructions there to link to both your {{page.num}} repo and your javadoc.
 
 If working in a pair, BOTH pair partners should do this, and if you ARE working in a pair, your submission on Gauchospace should indicate this.
 
-The Gauchospace link for {{page.num}} is: <{{page.gauchospace_url}}>
 
 Step 5: Submitting via submit.cs
 --------------------------------


### PR DESCRIPTION
This should probably depend on changes to Rational Example 8 getting merged first.  I put together https://github.com/UCSB-CS56-pconrad/cs56-rational-ex08/pull/2 with a tweaked `build.xml`.